### PR TITLE
Add tab navigation

### DIFF
--- a/scss/_homenav.scss
+++ b/scss/_homenav.scss
@@ -1,0 +1,18 @@
+.home-nav {
+  display: flex;
+  background-color: color(light-gray);
+  .home-nav-button {
+    width: 50%;
+    height: 100%;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: color(black);
+    &.selected {
+      color: white;
+      background-color: color(blue);
+    }
+  }
+}

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -124,6 +124,7 @@ goco-loader {
 
 @import "configuration";
 @import "home";
+@import "homenav";
 @import "icons";
 @import "login";
 @import "menu";

--- a/www/html/directives/_appheader.html
+++ b/www/html/directives/_appheader.html
@@ -1,4 +1,4 @@
-<ion-header-bar class="bar-light" align-title="center">
+<ion-header-bar class="light-gray" align-title="center">
   <div class="buttons">
     <button class="button button-icon ion-arrow-left-c"
       ng-if="backButton"

--- a/www/html/directives/_homenav.html
+++ b/www/html/directives/_homenav.html
@@ -1,0 +1,12 @@
+<ion-footer-bar class="bar-neutral home-nav">
+  <div class="home-nav-button"
+    ng-class="{selected: homeNav.isShown('info')}"
+    ng-click="homeNav.switch('info')">
+    Me
+  </div>
+  <div class="home-nav-button"
+    ng-class="{selected: homeNav.isShown('interaction')}"
+    ng-click="homeNav.switch('interaction')">
+    Gordon
+  </div>
+</ion-footer-bar>

--- a/www/html/home.html
+++ b/www/html/home.html
@@ -21,4 +21,5 @@
       module-control="moduleControl"></goco-module>
   </ion-content>
   <app-banner></app-banner>
+  <home-nav></home-nav>
 </ion-view>

--- a/www/index.html
+++ b/www/index.html
@@ -18,6 +18,7 @@
     <script src="js/directives/appHeader.js"></script>
     <script src="js/directives/gocoLoader.js"></script>
     <script src="js/directives/gocoModule.js"></script>
+    <script src="js/directives/homeNav.js"></script>
     <script src="js/directives/moduleViewHeader.js"></script>
     <script src="js/controllers/HomeController.js"></script>
     <script src="js/controllers/HighlandExpressController.js"></script>

--- a/www/js/directives/appHeader.js
+++ b/www/js/directives/appHeader.js
@@ -8,7 +8,6 @@ app.directive('appHeader', function () {
     templateUrl: 'html/directives/_appheader.html',
     controller: ['$rootScope', '$state', '$scope', '$ionicPopover', '$ionicModal', 'StorageService', 'PopupService', 'ModuleFactory', function ($rootScope, $state, $scope, $ionicPopover, $ionicModal, StorageService, PopupService, ModuleFactory) {
 
-      $scope.modules = ModuleFactory.getAllModules();
       $scope.selectedModules = ModuleFactory.getSelectedModules();
 
       $scope.updateModules = function () {
@@ -48,6 +47,10 @@ app.directive('appHeader', function () {
       };
 
       $scope.showConfigurationModal = function ($event) {
+        // Update list of modules
+        $scope.modules = ModuleFactory.getAllShownModules();
+
+        // Show modal
         configPromise.then(function () {
           $scope.configurationModal.show($event);
         });

--- a/www/js/directives/homeNav.js
+++ b/www/js/directives/homeNav.js
@@ -1,0 +1,19 @@
+app.directive('homeNav', function () {
+  return {
+    templateUrl: 'html/directives/_homenav.html',
+    controllerAs: 'homeNav',
+    controller: ['ModuleFactory', function (ModuleFactory) {
+      var homeNav = this;
+
+      // Switch which module type is shown
+      homeNav.switch = function (moduleType) {
+        ModuleFactory.changeModuleTypeShown(moduleType);
+      };
+
+      // Get whether or not module type is shown
+      homeNav.isShown = function (moduleType) {
+        return ModuleFactory.isModuleTypeShown(moduleType);
+      };
+    }]
+  };
+});

--- a/www/js/services/ModuleFactory.js
+++ b/www/js/services/ModuleFactory.js
@@ -7,16 +7,23 @@ app.factory('ModuleFactory', ['$rootScope', '$timeout', 'Modules', 'AppVersion',
   var _defaultModules = Modules;
   var _storedAppVersion = StorageService.get('version');
   var _currentAppVersion = AppVersion;
-  var _selectedModules = [];
-  var _numModules = 0;
-  var _moduleClass = '';
-  var _isScrollEnabled = false;
 
-  _allModules = _getAllModules();
-  _selectedModules = _getSelected(_allModules);
-  _numModules = _selectedModules.length;
-  _moduleClass = _getModuleClass(_numModules);
-  _isScrollEnabled = _getScrollEnabled(_numModules);
+  var _modules = {
+    'info': {
+      'selected': [],
+      'numSelected': 0,
+      'class': '',
+      'scrollEnabled': false,
+      'shown': true
+    },
+    'interaction': {
+      'selected': [],
+      'numSelected': 0,
+      'class': '',
+      'scrollEnabled': false,
+      'shown': false
+    }
+  };
 
   /**
    * Get all modules from either storage or constant
@@ -38,13 +45,24 @@ app.factory('ModuleFactory', ['$rootScope', '$timeout', 'Modules', 'AppVersion',
   }
 
   /**
+   * Get all shown modules
+   * @return {array}                    List of shown modules
+   */
+  function _getAllShownModules() {
+    return _allModules.filter(function (module) {
+      return _isModuleTypeShown(module.moduleType);
+    });
+  }
+
+  /**
    * Get selected modules from list of modules
    * @param  {array} modules Contains modules
+   * @param  {string} type   Type of modules to look for
    * @return {array}         Contains modules with 'selected': true
    */
-  function _getSelected(modules) {
+  function _getSelected(modules, type) {
     return modules.filter(function (module) {
-        return module.selected === true;
+        return module.selected === true && module.moduleType == type;
       });
   }
 
@@ -73,18 +91,62 @@ app.factory('ModuleFactory', ['$rootScope', '$timeout', 'Modules', 'AppVersion',
   }
 
   /**
+   * Change which module type is shown
+   * @param  {string} moduleType Type of module to show
+   */
+  function _changeModuleTypeShown(moduleType) {
+      _modules[moduleType].shown = true;
+
+      // Identify opposite module type and set 'shown' property to false
+      if (moduleType == 'info') {
+        _modules.interaction.shown = false;
+      } else {
+        _modules.info.shown = false;
+      }
+      moduleFactory.updateModules();
+  }
+
+  /**
+   * Return whether module type is shown or not
+   * @param  {string}  moduleType Type of module
+   * @return {Boolean}            Whether module type is shown or not
+   */
+  function _isModuleTypeShown(moduleType) {
+    return _modules[moduleType].shown;
+  }
+
+  /**
+   * Return shown module type
+   * @return {string}            Type of module that is currently shown
+   */
+  function _getModuleTypeShown() {
+    if (_modules.info.shown) {
+      return 'info';
+    } else {
+      return 'interaction';
+    }
+  }
+
+  /**
    * Update list of selected modules from list of all modules
    */
   moduleFactory.updateModules = function (modules) {
     _allModules = modules || _getAllModules();
-    _selectedModules = _getSelected(_allModules);
 
-    _numModules = _selectedModules.length;
-    _moduleClass = _getModuleClass(_numModules);
-    _isScrollEnabled = _getScrollEnabled(_numModules);
+    _modules.info.selected = _getSelected(_allModules, 'info');
+    _modules.interaction.selected = _getSelected(_allModules, 'interaction');
+
+    _modules.info.numSelected = _modules.info.selected.length;
+    _modules.interaction.numSelected = _modules.interaction.selected.length;
+
+    _modules.info.class = _getModuleClass(_modules.info.numSelected);
+    _modules.interaction.class = _getModuleClass(_modules.interaction.numSelected);
+
+    _modules.info.scrollEnabled = _getScrollEnabled(_modules.info.numSelected);
+    _modules.interaction.scrollEnabled = _getScrollEnabled(_modules.interaction.numSelected);
 
     StorageService.storeModules(_allModules);
-    $rootScope.$broadcast('modules:updated', _selectedModules);
+    $rootScope.$broadcast('modules:updated', _modules);
   };
 
   /**
@@ -96,11 +158,19 @@ app.factory('ModuleFactory', ['$rootScope', '$timeout', 'Modules', 'AppVersion',
   };
 
   /**
+   * Get all shown modules
+   * @return {array} List of module objects
+   */
+  moduleFactory.getAllShownModules = function () {
+    return _getAllShownModules();
+  };
+
+  /**
    * Get selected modules
    * @return {array}           List of selected modules
    */
   moduleFactory.getSelectedModules = function () {
-    return _selectedModules;
+    return _modules[_getModuleTypeShown()].selected;
   };
 
   /**
@@ -108,7 +178,7 @@ app.factory('ModuleFactory', ['$rootScope', '$timeout', 'Modules', 'AppVersion',
    * @return {String}           Class for modules determining their size
    */
   moduleFactory.getModuleClass = function () {
-    return _moduleClass;
+    return _modules[_getModuleTypeShown()].class;
   };
 
   /**
@@ -116,8 +186,27 @@ app.factory('ModuleFactory', ['$rootScope', '$timeout', 'Modules', 'AppVersion',
    * @return {Boolean} Whether scroll is enabled or not
    */
   moduleFactory.getScrollEnabled = function () {
-    return _isScrollEnabled;
+    return _modules[_getModuleTypeShown()].scrollEnabled;
   };
+
+  /**
+   * Change module type shown
+   * @param  {string} moduleType Type of module
+   */
+  moduleFactory.changeModuleTypeShown = function (moduleType) {
+    _changeModuleTypeShown(moduleType);
+  };
+
+  /**
+   * Return whether module type is shown or not
+   * @param  {string}  moduleType Type of module
+   * @return {Boolean}            Whether module type is shown or not
+   */
+  moduleFactory.isModuleTypeShown = function (moduleType) {
+    return _isModuleTypeShown(moduleType);
+  };
+
+  moduleFactory.updateModules();
 
   return moduleFactory;
 }]);


### PR DESCRIPTION
Add tab navigation to the home screen so the user can navigate between info and interaction modules, because there are too many modules to display both types on the same screen.

Closes #59.
