### PR TITLE
Feature: Add HTTP method to module configuration

### DIFF
--- a/www/html/home.html
+++ b/www/html/home.html
@@ -12,6 +12,7 @@
       ng-repeat="module in home.selectedModules"
       ng-show="module.moduleType == moduleTypeShown"
       module-type="module.moduleType"
+      http-method="module.httpMethod"
       endpoint="module.endpoint"
       label="module.label"
       icon="module.icon"

--- a/www/js/constants.js
+++ b/www/js/constants.js
@@ -1,5 +1,4 @@
-//app.constant('ApiUrl', 'https://gocostudent.adamvig.com/api/").
-app.constant("ApiUrl", "http://local.dev:4626/api/").
+app.constant("ApiUrl", "https://gocostudent.adamvig.com/api/").
 constant("RequestTimeout", {
   "default": 25000
 }).

--- a/www/js/constants.js
+++ b/www/js/constants.js
@@ -25,6 +25,7 @@ constant("DefaultModuleSettings", {
 constant("Modules", [
   {
     "moduleType": "info",
+    "httpMethod": "post",
     "endpoint": "chapelCredits",
     "label": "CL&W Credits",
     "icon": "chapel-icon",
@@ -34,6 +35,7 @@ constant("Modules", [
   },
   {
     "moduleType": "info",
+    "httpMethod": "post",
     "endpoint": "mealPoints",
     "label": "Mealpoints",
     "icon": "meal-points-icon",
@@ -43,6 +45,7 @@ constant("Modules", [
   },
   {
     "moduleType": "info",
+    "httpMethod": "post",
     "endpoint": "mealPointsPerDay",
     "label": "Mealpoints Left/Day",
     "icon": "calculator-icon",
@@ -52,6 +55,7 @@ constant("Modules", [
   },
   {
     "moduleType": "info",
+    "httpMethod": "get",
     "endpoint": "daysLeftInSemester",
     "label": "Days Left In Semester",
     "icon": "calendar-icon",
@@ -61,6 +65,7 @@ constant("Modules", [
   },
   {
     "moduleType": "info",
+    "httpMethod": "post",
     "endpoint": "studentID",
     "label": "Student ID",
     "icon": "person-icon",
@@ -70,6 +75,7 @@ constant("Modules", [
   },
   {
     "moduleType": "info",
+    "httpMethod": "get",
     "endpoint": "temperature",
     "label": "Temperature",
     "icon": "thermometer-icon",
@@ -79,6 +85,7 @@ constant("Modules", [
   } ,
   {
     "moduleType": "interaction",
+    "httpMethod": "post",
     "endpoint": "chapelEvents",
     "label": "CL&W Events",
     "icon": "bible-icon",
@@ -88,6 +95,7 @@ constant("Modules", [
   },
   {
     "moduleType": "interaction",
+    "httpMethod": "get",
     "endpoint": "highlandExpress",
     "label": "Highland Express",
     "icon": "highland-express-icon",
@@ -97,6 +105,7 @@ constant("Modules", [
   },
   {
     "moduleType": "interaction",
+    "httpMethod": "get",
     "endpoint": "athleticsSchedule",
     "label": "Athletics Schedule",
     "icon": "fighting-scots-icon",
@@ -106,6 +115,7 @@ constant("Modules", [
   },
   {
     "moduleType": "interaction",
+    "httpMethod": "post",
     "endpoint": "nextMeal",
     "label": "Next Meal",
     "icon": "plate-icon",

--- a/www/js/directives/gocoModule.js
+++ b/www/js/directives/gocoModule.js
@@ -57,7 +57,16 @@ app.directive("gocoModule", function () {
           DbFactory.getCredentials().then(function (userCredentials) {
             if (userCredentials) {
               hasCredentials = true;
-              return DataService.post(module.endpoint, userCredentials);
+
+              // Use HTTP method specified in module configuration
+              if (module.httpMethod === "post") {
+                return DataService.post(module.endpoint, userCredentials);
+              } else if (module.httpMethod === "get") {
+                return DataService.get(module.endpoint);
+              } else {
+                throw new Error("Method " + module.httpMethod + " not supported.");
+              }
+
             } else {
               throw new ReferenceError("No user credentials found in database.");
             }

--- a/www/js/directives/gocoModule.js
+++ b/www/js/directives/gocoModule.js
@@ -3,6 +3,7 @@ app.directive("gocoModule", function () {
     restrict: "E",
     scope: {
       moduleType: "=",
+      httpMethod: "=",
       endpoint: "=",
       label: "=",
       icon: "=",
@@ -20,6 +21,7 @@ app.directive("gocoModule", function () {
       module.loading = null;
 
       module.moduleType = $scope.moduleType;
+      module.httpMethod = $scope.httpMethod;
       module.endpoint = $scope.endpoint;
       module.label = $scope.label;
       module.icon = $scope.icon;

--- a/www/js/services/DataService.js
+++ b/www/js/services/DataService.js
@@ -3,12 +3,11 @@ app.service("DataService", ["$http", "ApiUrl", "RequestTimeout", "DefaultSetting
   /**
    * Retrieve data for user from server using a GET request
    * @param  {String}   dataType        Type of data to get, ex: "chapelCredits"
-   * @param  {object}   userCredentials Contains username and password
    * @param  {number}   timeout         Custom timeout in milliseconds
    * @param  {function} timeout         Custom timeout function
    * @return {promise}                  Fulfilled by response from server
    */
-  this.get = function (dataType, userCredentials, timeout) {
+  this.get = function (dataType, timeout) {
 
     var url = ApiUrl + DefaultSettings.appVersion + "/" + dataType.toLowerCase();
 
@@ -21,7 +20,6 @@ app.service("DataService", ["$http", "ApiUrl", "RequestTimeout", "DefaultSetting
 
     // Request configuration
     var config = {
-      params: userCredentials,
       timeout: timeout || RequestTimeout.default,
       headers: {
         "X-Platform": ionic.Platform.platform(),


### PR DESCRIPTION
Modules can now use either `GET` or `POST` requests to interact with their respective endpoints on the API.
